### PR TITLE
Add grape submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "grape"]
+	path = grape
+	url = https://github.com/surrsurus/grape


### PR DESCRIPTION
# Add grape to oc-scripts

This PR adds grape as an oc-script submodule. I was dumb and didn't see there was a nice repo for our oc-scripts so I made a grape repo. Please fix this (my) issue by adding grape as a submodule. Thank you.